### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/src/runtime/composables/useAppwrite.ts
+++ b/src/runtime/composables/useAppwrite.ts
@@ -1,5 +1,5 @@
 import { Appwrite } from '../plugin'
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 
 export const useAppwrite = () => {
   const { $appwrite } = useNuxtApp()

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -15,7 +15,7 @@ import {
   Teams
 } from 'appwrite'
 import { ModuleOptions } from '../module'
-import { defineNuxtPlugin } from '#app'
+import { defineNuxtPlugin } from '#imports'
 
 export type AppwriteConfig = {
   endpoint: string;


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.